### PR TITLE
Fixed make error of not enough function parameters given for rsxInit

### DIFF
--- a/src/video/psl1ght/SDL_PSL1GHTvideo.c
+++ b/src/video/psl1ght/SDL_PSL1GHTvideo.c
@@ -111,7 +111,7 @@ void initializeGPU( SDL_DeviceData * devdata)
     assert(host_addr != NULL);
 
     // Initilise Reality, which sets up the command buffer and shared IO memory
-    devdata->_CommandBuffer = rsxInit(0x10000, 1024*1024, host_addr);
+    rsxInit(&devdata->_CommandBuffer, 0x10000, 1024*1024, host_addr);
     assert(devdata->_CommandBuffer != NULL);
 }
 


### PR DESCRIPTION
Fixed a "make" call error that would prevent the build because of not enough arguments given to rsxInit